### PR TITLE
Cast waveform to float before resample_poly

### DIFF
--- a/wavelet_prosody_toolkit/prosody_tools/misc.py
+++ b/wavelet_prosody_toolkit/prosody_tools/misc.py
@@ -100,7 +100,7 @@ def resample(waveform, s_sr, t_sr):
     returns: resampled waveform as np.array
     """
     ratio = fractions.Fraction(int(t_sr), int(s_sr))
-    return resample_poly(waveform, ratio.numerator, ratio.denominator)
+    return resample_poly(waveform.astype(np.float), ratio.numerator, ratio.denominator)
 
 
 def play(utt):


### PR DESCRIPTION
Per [this](https://github.com/scipy/scipy/issues/15620) bug, we need to recast the waveform or it will produce all zeroes in resample_poly.